### PR TITLE
Make relative path for rx module

### DIFF
--- a/rx.dom.js
+++ b/rx.dom.js
@@ -10,7 +10,7 @@
 
     // Because of build optimizers
     if (typeof define === 'function' && define.amd) {
-        define(['rx', 'exports'], function (Rx, exports) {
+        define(['./rx', 'exports'], function (Rx, exports) {
             root.Rx = factory(root, exports, Rx);
             return root.Rx;
         });


### PR DESCRIPTION
When the path is not relative and the path configuration is used with an AMD module the <script src="rx.js" /> is added to the pate instead of the <srcript src="mypath/rx.js" /> link
