### PR TITLE
Allow static JSONP callbacks

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -235,6 +235,7 @@ Rx.DOM.Request.jsonpRequest(settings);
 1. `settings` *(Object)*: An object with the following properties:
 		- `url` *(String)*: URL of the request
   		- `jsonp` *(String)*: The named callback parameter for the JSONP call
+  		- `jsonpCallback` *(String)*: Name of the function in the root object that JSONP will call. This is useful for when the JSONP callback is hardcoded and can't be changed
 
 #### Returns
 *(Observable)*: A hot observable containing the results from the JSONP call.

--- a/tests/tests.ajax.js
+++ b/tests/tests.ajax.js
@@ -1,4 +1,4 @@
-var xhr, requests
+var xhr, requests;
 
 module('Ajax Tests', {
 	setup: function () {
@@ -590,4 +590,59 @@ test('getJSON failure', function () {
 	);
 
 	requests[0].respond(500, { 'Content-Type': 'application/json' }, 'error');
+});
+
+asyncTest('jsonpRequest with jsonp callback success', function () {
+	window.testCallback = function(observer, data) {
+		data[0].correct = true;
+		observer.onNext(data);
+		observer.onCompleted();
+	};
+	
+	var fakeScript = "data:text/javascript;base64," + btoa(
+		'testCallback([{ "id": 123 }])'
+	);
+	
+	var source = Rx.DOM.Request.jsonpRequest({
+		url: fakeScript,
+		jsonpCallback: 'testCallback'
+	});
+
+	source.subscribe(
+		function (x) {
+			equal(123, x[0].id);
+			equal(true, x[0].correct);
+		},
+		function (e) { 
+			ok(false); 
+		},
+		function () {
+			ok(true);
+			QUnit.start();
+		}
+	);
+});
+
+asyncTest('jsonpRequest without jsonp callback success', function () {
+	var fakeScript = "data:text/javascript;base64," + btoa(
+		'testCallback([{ "id": 123 }])'
+	);
+
+	var source = Rx.DOM.Request.jsonpRequest({
+		url: fakeScript,
+		jsonpCallback: 'testCallback'
+	});
+
+	source.subscribe(
+		function (x) {
+			equal(123, x[0].id);
+		},
+		function (e) { 
+			ok(false); 
+		},
+		function () {
+			ok(true);
+			QUnit.start();
+		}
+	);
 });


### PR DESCRIPTION
RxJS now only works with JSONP responses that can be changed via querystring. There are several services out there that provide a static callback, which name can't be changed by the requester. An example of this is the realtime JSOP feed at [USGS](http://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_hour.geojsonp), which forces the program to have a callback called `eqfeed_callback`.

This patch emulates what the [jQuery API](https://github.com/jquery/jquery/blob/master/src/ajax/jsonp.js#L36) does (but only allows `jsonCallback` to be a string), and introduces a new optional `jsonpCallback` property for the `settings` parameter for `jsonpRequest` and to `jsonpRequestCold`. It doesn't change the previous behavior in any way.
