### PR TITLE
Bugfix and simplify JSONP callback call when the callback name is fixed by the remote

### DIFF
--- a/src/jsonp.js
+++ b/src/jsonp.js
@@ -12,7 +12,7 @@
   /**
    * Creates a cold observable JSONP Request with the specified settings.
    *
-   * @example 
+   * @example
    *   source = Rx.DOM.jsonpRequest('http://www.bing.com/?q=foo&JSONPRequest=?');
    *   source = Rx.DOM.jsonpRequest( url: 'http://bing.com/?q=foo', jsonp: 'JSONPRequest' });
    *
@@ -41,28 +41,28 @@
         var head = document.getElementsByTagName('head')[0] || document.documentElement,
           tag = document.createElement('script'),
           handler = 'rxjscallback' + uniqueId++;
-          
-        var prevFn;
+
         if (typeof settings.jsonpCallback === 'string') {
           handler = settings.jsonpCallback;
-          prevFn = root[handler];
         }
 
         settings.url = settings.url.replace('=' + settings.jsonp, '=' + handler);
 
-        root[handler] = function(data) {
-          if (prevFn && typeof prevFn === 'function') {
-            prevFn(observer, data);
-          } else {
-            defaultCallback(observer, data);
+        var existing = root[handler];
+        root[handler] = function(data, recursed) {
+          if (existing) {
+            existing(data, true) && (existing = null);
+            return false;
           }
+          defaultCallback(observer, data);
+          !recursed && (root[handler] = null);
+          return true;
         };
 
         var cleanup = function _cleanup() {
           tag.onload = tag.onreadystatechange = null;
           head && tag.parentNode && destroy(tag);
           tag = undefined;
-          root[handler] = prevFn;
         };
 
         tag.src = settings.url;
@@ -71,7 +71,7 @@
           if ( abort || !tag.readyState || /loaded|complete/.test(tag.readyState) ) {
             cleanup();
           }
-        };  
+        };
         head.insertBefore(tag, head.firstChild);
 
         return function () {

--- a/tests/tests.jsonp.js
+++ b/tests/tests.jsonp.js
@@ -6,11 +6,11 @@ asyncTest('jsonpRequest with jsonp callback success', function () {
     observer.onNext(data);
     observer.onCompleted();
   };
-  
+
   var fakeScript = "data:text/javascript;base64," + btoa(
     'testCallback([{ "id": 123 }])'
   );
-  
+
   var source = Rx.DOM.jsonpRequest({
     url: fakeScript,
     jsonpCallback: 'testCallback'
@@ -21,8 +21,8 @@ asyncTest('jsonpRequest with jsonp callback success', function () {
       equal(123, x[0].id);
       equal(true, x[0].correct);
     },
-    function (e) { 
-      ok(false); 
+    function (e) {
+      ok(false);
     },
     function () {
       ok(true);
@@ -45,8 +45,50 @@ asyncTest('jsonpRequest without jsonp callback success', function () {
     function (x) {
       equal(123, x[0].id);
     },
-    function (e) { 
-      ok(false); 
+    function (e) {
+      ok(false);
+    },
+    function () {
+      ok(true);
+      QUnit.start();
+    }
+  );
+});
+
+asyncTest('jsonpRequest without jsonp callback success with 2 observers', function () {
+  var fakeScript = "data:text/javascript;base64," + btoa(
+    'testCallback([{ "id": 123 }])'
+  );
+
+  var source = Rx.DOM.jsonpRequest({
+    url: fakeScript,
+    jsonpCallback: 'testCallback'
+  });
+
+  source.subscribe(
+    function (x) {
+      equal(123, x[0].id);
+    },
+    function (e) {
+      ok(false);
+    },
+    function () {
+      ok(true);
+      QUnit.start();
+    }
+  );
+
+  var source2 = Rx.DOM.jsonpRequest({
+    url: fakeScript,
+    jsonpCallback: 'testCallback'
+  });
+
+  source2.subscribe(
+    function (x) {
+      equal(123, x[0].id);
+    },
+    function (e) {
+      ok(false);
     },
     function () {
       ok(true);


### PR DESCRIPTION
The bug is one in which a callback in a fixed jsonp scenario would be called with an Observable as a first parameter, instead of the data padded in the JSONP.