### PR TITLE
Fix code not matching documentation and more

### DIFF
--- a/src/jsonp.js
+++ b/src/jsonp.js
@@ -13,8 +13,8 @@
    * Creates a cold observable JSONP Request with the specified settings.
    *
    * @example
-   *   source = Rx.DOM.jsonpRequest('http://www.bing.com/?q=foo&JSONPRequest=?');
-   *   source = Rx.DOM.jsonpRequest( url: 'http://bing.com/?q=foo', jsonp: 'JSONPRequest' });
+   *   source = Rx.DOM.jsonpRequest('http://www.bing.com/?q=foo&JSONPCallback=?');
+   *   source = Rx.DOM.jsonpRequest( url: 'http://bing.com/?q=foo', jsonp: 'JSONPCallback' });
    *
    * @param {Object} settings Can be one of the following:
    *
@@ -46,7 +46,7 @@
           handler = settings.jsonpCallback;
         }
 
-        settings.url = settings.url.replace('=' + settings.jsonp, '=' + handler);
+        settings.url = settings.url.replace(new RegExp('([?|&]'+settings.jsonp+'=)[^\&]+'), '$1' + handler);
 
         var existing = root[handler];
         root[handler] = function(data, recursed) {


### PR DESCRIPTION
Closes #45 and closes #46

Code now correctly replaces callback parameter value based on the
callback parameter name. Also made use of JSONPCallback in documentation
consistent.

This change also solves the issue of TypeErrors when the settings object
is reused amongst multiple requests.

No tests are changed since this behaviour was not tested before and doesn't fit well in the current automated test setup.