### PR TITLE
Fix CORS support check

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -24,8 +24,9 @@
 
   // Get CORS support even for older IE
   function getCORSRequest() {
-    if ('withCredentials' in root.XMLHttpRequest.prototype) {
-      return new root.XMLHttpRequest();
+    var xhr = new root.XMLHttpRequest();
+    if ('withCredentials' in xhr) {
+      return xhr;
     } else if (!!root.XDomainRequest) {
       return new XDomainRequest();
     } else {


### PR DESCRIPTION
`XMLHttpRequest.prototype` doesn't have `withCredentials` property (at least in Chrome for Mac 42.0.2311.135)