### PR TITLE
There is no "close" method for Worker object

### DIFF
--- a/src/webworker.js
+++ b/src/webworker.js
@@ -20,7 +20,7 @@
       worker.addEventListener('error', errHandler, false);
 
       return function () {
-        worker.close();
+        worker.terminate();
         worker.removeEventListener('message', messageHandler, false);
         worker.removeEventListener('error', errHandler, false);
       };


### PR DESCRIPTION
Hi all,

I've found some weird issue in web worker wrapper. According to [MDN article](https://developer.mozilla.org/en/docs/Web/API/Worker) there is no "close" method for worker instance but there is "terminate" method instead.

Unfortunately, there is no any tests for this module.

I'm sorry, If this PR looks wrong according to contribution style.