### PR TITLE
Use SPDX license identifier in package meta files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,11 @@
     "dist/rx.dom.js",
     "dist/rx.dom.compat.js"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Reactive-Extensions/RxJS-DOM.git"
+  },
+  "license": "Apache-2.0",
   "dependencies": {
     "rxjs": "*"
   },

--- a/package.json
+++ b/package.json
@@ -12,12 +12,7 @@
     "type": "git",
     "url": "https://github.com/Reactive-Extensions/RxJS-DOM.git"
   },
-  "licenses": [
-    {
-      "type": "Apache License, Version 2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    }
-  ],
+  "license": "Apache-2.0",
   "dependencies": {
     "rx": "*"
   },


### PR DESCRIPTION
- Change license field to use [SPDX license identifier](https://spdx.org/licenses/)
- Add license field to `bower.json`

The PR makes automatic license detection easier for third party packagers (especially http://webjars.org in my use case)