### PR TITLE
Fix root document in non browser env

### DIFF
--- a/src/jsonp.js
+++ b/src/jsonp.js
@@ -45,7 +45,7 @@
            }
          }
 
-         var script = document.createElement('script');
+         var script = root.document.createElement('script');
          script.type = 'text/javascript';
          script.async = settings.async;
          script.src = settings.url.replace(settings.jsonp, settings.jsonpCallback);
@@ -83,7 +83,7 @@
 
          script.onload = script.onreadystatechanged = script.onerror = handler;
 
-         var head = document.getElementsByTagName('head')[0] || document.documentElement;
+         var head = root.document.getElementsByTagName('head')[0] || root.document.documentElement;
          head.insertBefore(script, head.firstChild);
 
          return function() {

--- a/src/jsonp.js
+++ b/src/jsonp.js
@@ -2,7 +2,7 @@
    * Destroys the current element
    */
   var destroy = (function () {
-    var trash = document.createElement('div');
+    var trash = 'document' in root && root.document.createElement('div');
     return function (element) {
       trash.appendChild(element);
       trash.innerHTML = '';

--- a/src/microtaskscheduler.js
+++ b/src/microtaskscheduler.js
@@ -52,7 +52,7 @@
         })
       });
 
-      var element = document.createElement('div');
+      var element = root.document.createElement('div');
       observer.observe(element, { attributes: true });
 
       // Prevent leaks

--- a/src/ready.js
+++ b/src/ready.js
@@ -11,17 +11,17 @@
         observer.onCompleted();
       }
 
-      if (document.readyState === 'complete') {
+      if (root.document.readyState === 'complete') {
         setTimeout(handler, 0);
       } else {
         addedHandlers = true;
-        document.addEventListener( 'DOMContentLoaded', handler, false );
+        root.document.addEventListener( 'DOMContentLoaded', handler, false );
         root.addEventListener( 'load', handler, false );
       }
 
       return function () {
         if (!addedHandlers) { return; }
-        document.removeEventListener( 'DOMContentLoaded', handler, false );
+        root.document.removeEventListener( 'DOMContentLoaded', handler, false );
         root.removeEventListener( 'load', handler, false );
       };
     });


### PR DESCRIPTION
In a server-side environment like `node.js`, referencing `document` directly will throw `ReferenceError`. This PR fixes it by changing the calls to `root.document`, allowing isomorphic app like `React` with `Rx` being able to render in the server-side without error.

An alternative approach for this is using `webpack` to generate `dist` files. Webpack will automatically shmming `global` variable in browser environment so our codebase will have one consistent `global` calls. No more implicit `root` variables.