### PR TITLE
Clean up get and post examples.

### DIFF
--- a/doc/operators/get.md
+++ b/doc/operators/get.md
@@ -13,8 +13,8 @@ Creates an observable sequence from an Ajax GET Request with the body.  This is 
 ```js
 Rx.DOM.get('/products')
   .subscribe(
-    function (xhr) {
-      var text = xhr.response;
+    function (data) {
+      var text = data.response;
       console.log(text);
     },
     function (err) {

--- a/doc/operators/post.md
+++ b/doc/operators/post.md
@@ -14,8 +14,8 @@ Creates an observable sequence from an Ajax POST Request with the body.  This is
 ```js
 Rx.DOM.post('/test', { text: 'sometext' })
   .subscribe(
-    function (xhr) {
-      console.log(xhr.response);
+    function (data) {
+      console.log(data.response);
     },
     function (err) {
       // Log the error


### PR DESCRIPTION
'xhr' is misleading because it is not an instance of XmlHTTPRequest.