### PR TITLE
Correct typos in frommutationobserver.md

### DIFF
--- a/doc/operators/frommutationobserver.md
+++ b/doc/operators/frommutationobserver.md
@@ -18,7 +18,8 @@ var obs = Rx.DOM.fromMutationObserver(foo, {
   attributes: true, 
   childList: true, 
   characterData: true,
-  attributeFilter: ["id", "dir"]
+  attributeFilter: ["id", "dir"],
+  attributeOldValue: true
 });
 
 foo.dir = 'rtl';
@@ -29,7 +30,7 @@ obs.subscribe(function (mutations) {
     console.log("Type of mutation: " + mutation.type);
 
     if ("attributes" === mutation.type) {
-      console.log("Old attribute value: " + mutationRecord.oldValue);
+      console.log("Old attribute value: " + mutation.oldValue);
     }
   });
 });


### PR DESCRIPTION
Correct typos regarding setting a observerConfig & retrieving old values from a MutationRecord returned from a MutationObserver in an example in frommutationobserver.md

Typos caused old values from an attribute change from `foo` unable to be retrieved & caused a reference error to propagate because `mutationRecord` is undefined.

LIkely may lead to unfounded conclusions about this method if a reader isn't already familiar with mutation observers as I am. 