### PR TITLE
Remove unused variable from ajax.js

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -205,7 +205,7 @@ function normalizeAjaxSuccessEvent(e, xhr, settings) {
    * @param {String} url The URL to GET
    * @returns {Observable} The observable sequence which contains the response from the Ajax GET.
    */
-  var observableGet = dom.get = function (url) {
+  dom.get = function (url) {
     return ajaxRequest({ url: url });
   };
 


### PR DESCRIPTION
`observableGet` isn't being referenced anywhere after it is defined.