### PR TITLE
Fix example websockets.org URL to websocket.org

### DIFF
--- a/doc/operators/fromwebsocket.md
+++ b/doc/operators/fromwebsocket.md
@@ -29,7 +29,7 @@ var closingObserver = Rx.Observer.create(function() {
 
 // create a web socket subject
 socket = Rx.DOM.fromWebSocket(
-  'ws://echo.websockets.org',
+  'ws://echo.websocket.org',
   null, // no protocol
   openObserver,
   closingObserver);


### PR DESCRIPTION
Update incorrect code example URL ws://echo.websockets.org to ws://echo.websocket.org