### PR TITLE
Xdr blob: added option `withCredentials` for CORS requests. added mention of 'blob' contentType to documentation.

### DIFF
--- a/dist/rx.dom.js
+++ b/dist/rx.dom.js
@@ -257,7 +257,7 @@
   function getCORSRequest() {
     var xhr = new root.XMLHttpRequest();
     if ('withCredentials' in xhr) {
-      xhr.withCredentials = true;
+      xhr.withCredentials = this.withCredentials ? true : false;
       return xhr;
     } else if (!!root.XDomainRequest) {
       return new XDomainRequest();
@@ -436,8 +436,9 @@
       headers: {},
       responseType: 'text',
       timeout: 0,
+      withCredentials: false,
       createXHR: function(){
-        return this.crossDomain ? getCORSRequest() : getXMLHttpRequest()
+        return this.crossDomain ? getCORSRequest.call(this) : getXMLHttpRequest()
       },
       normalizeError: normalizeAjaxErrorEvent,
       normalizeSuccess: normalizeAjaxSuccessEvent

--- a/dist/rx.dom.js
+++ b/dist/rx.dom.js
@@ -326,6 +326,10 @@
           xhr.open(settings.method, settings.url, settings.async);
         }
 
+        if (settings.responseType === 'blob') {
+          xhr.responseType = 'blob';
+        }
+        
         var headers = settings.headers;
         for (var header in headers) {
           if (hasOwnProperty.call(headers, header)) {

--- a/doc/operators/ajax.md
+++ b/doc/operators/ajax.md
@@ -14,11 +14,12 @@ OR
     - `async` *(Boolean)*: Whether the request is async. The default is `true`.
     - `body` *(Object)*: Optional body
     - `crossDomain` *(Boolean)*: true if to use CORS, else false. The default is `false`.
+    - `withCredentials` *(Boolean)*: true if to use CORS withCredentials, else false. The default is `false`.
     - `headers` *(Object)*: Optional headers
     - `method` *(String)*: Method of the request, such as GET, POST, PUT, PATCH, DELETE. The default is GET.
     - `password` *(String)*: The password for the request.
     - `progressObserver` *(Observer)*: An optional `Observer` which listen to XHR2 progress events or error timeout values.
-    - `responseType` *(String)*: The response type. Either can be 'json' or 'text'. The default is 'text'
+    - `responseType` *(String)*: The response type. Either can be 'json', 'text' or 'blob'. The default is 'text'
     - `timeout`: `Number` - a number representing the number of milliseconds a request can take before automatically being terminated. A value of 0 (which is the default) means there is no timeout.
     - `url` *(String)*: URL of the request
     - `user` *(String)*: The user for the request.

--- a/src/ajax/ajax.js
+++ b/src/ajax/ajax.js
@@ -95,6 +95,10 @@
           xhr.open(settings.method, settings.url, settings.async);
         }
 
+        if (settings.responseType === 'blob') {
+          xhr.responseType = 'blob';
+        }
+        
         var headers = settings.headers;
         for (var header in headers) {
           if (hasOwnProperty.call(headers, header)) {

--- a/src/ajax/ajax.js
+++ b/src/ajax/ajax.js
@@ -26,7 +26,7 @@
   function getCORSRequest() {
     var xhr = new root.XMLHttpRequest();
     if ('withCredentials' in xhr) {
-      xhr.withCredentials = true;
+      xhr.withCredentials = this.withCredentials ? true : false;
       return xhr;
     } else if (!!root.XDomainRequest) {
       return new XDomainRequest();
@@ -205,8 +205,9 @@
       headers: {},
       responseType: 'text',
       timeout: 0,
+      withCredentials: false,
       createXHR: function(){
-        return this.crossDomain ? getCORSRequest() : getXMLHttpRequest()
+        return this.crossDomain ? getCORSRequest.call(this) : getXMLHttpRequest()        
       },
       normalizeError: normalizeAjaxErrorEvent,
       normalizeSuccess: normalizeAjaxSuccessEvent


### PR DESCRIPTION
Xdr blob: added option `withCredentials` for CORS requests. added mention of 'blob' contentType to documentation.

With this change, this request succeeds

```javascript
rx.DOM.ajax({
  url          : 'http://d8d913s460fub.cloudfront.net/videoserver/cat-test-video-320x240.mp4',
  crossDomain  : true,
  responseType : 'blob'
}).subscribe(
  function (data) {
    console.log('next ', data);
  },
  function (error) {
    // Log the error
  },
  function (complete) {
    console.log('complete');
  }
);
```