### PR TITLE
Remove outdated version in Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "rxjs-dom",
-  "version": "6.0.0",
   "main": [
     "dist/rx.dom.js",
     "dist/rx.dom.compat.js"


### PR DESCRIPTION
version

Deprecated

Use git or svn tags instead. This field is ignored by Bower.
https://github.com/bower/spec/blob/master/json.md#version